### PR TITLE
Updated Immutable-history with redo functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ It is inspired by ideas from [om](https://github.com/swannodette/om) and works
 great with [React](https://github.com/facebook/react) but you can use it for
 `(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ A N Y T H I N G (ಥ﹏ಥ)`!
 
+### This fork has been updated with the added ability to "redo"
+tests have been added for the new functionlity. The Usage code below has been updated as well.
+
 
 ## Installation
 
@@ -38,6 +41,8 @@ function render(cursor) {
     } else {
       // go back to the previous state of the cursor
       history.undo()
+      //go forward to the the state you just undo'd from
+      history.redo()
     }
   }, 500);
   console.log(cursor);

--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ History.prototype.undoUntilData = function(data) {
   this.history = this.history.takeWhile(function(v) {
     return v != data;
   }).toList().push(data);
-  var newData = data;
   this.cursor = Cursor.from(data, [], this._onChange);
   this._emitChange()
   return data;

--- a/index.js
+++ b/index.js
@@ -23,12 +23,14 @@ function History(immutableCollection, changed) {
   // Immutable.List will coerce other data types to a list, and will
   // silently fail to wrap a List in another list, so we do it ourselves
   this.history = Immutable.List([immutableCollection]);
+  this.forwardHistory = Immutable.List([]);
   this.emitter = new events.EventEmitter();
   this.changed = changed;
   var self = this;
 
   this._onChange = function(newData, oldData, path) {
     self.history = self.history.push(newData);
+    self.forwardHistory.clear();
     self.cursor = Cursor.from(newData, [], self._onChange);
     self._emitChange()
   }
@@ -60,12 +62,25 @@ History.prototype.undoUntilData = function(data) {
   }).toList().push(data);
   var newData = data;
   this.cursor = Cursor.from(data, [], this._onChange);
-  self._emitChange()
+  this._emitChange()
   return data;
 }
 
 History.prototype.undo = function() {
+  this.forwardHistory = this.forwardHistory.push(this.history.last());
   return this.undoUntilData(this.previousVersion());
+}
+
+History.prototype.redo = function() {
+  if(this.forwardHistory.count() == 0)
+    return this.history.last();
+
+  data = this.forwardHistory.last();
+  this.forwardHistory = this.forwardHistory.pop();
+  this.history = this.history.push(data);
+  this.cursor = Cursor.from(data, [], this._onChange);
+  this._emitChange();
+  return data;
 }
 
 History.prototype.onChange = function(handler) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Immutable = require('immutable');
-var Cursor = require('immutable-cursor');
+var Cursor = require('immutable/contrib/cursor');
 var events = require('events')
 
 var EVENT_CHANGE = 'change'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Immutable = require('immutable');
-var Cursor = require('immutable/contrib/cursor');
+var Cursor = require('immutable-cursor');
 var events = require('events')
 
 var EVENT_CHANGE = 'change'

--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "name": "immutable-history",
+  "version": "0.2.1",
+  "author": "Jamison Dance <jergason@gmail.com> (http://jamisondance.com)",
+  "repository": "https://github.com/kualico/immutable-history",
+  "contributors": [
+    "Sean Hess <seanhess@gmail.com> (http://seanhess.github.io/)"
+  ],
   "description": "History tracking wrapper for Immutable.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immutable-history",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Jamison Dance <jergason@gmail.com> (http://jamisondance.com)",
   "repository": "https://github.com/kualico/immutable-history",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,11 +1,4 @@
 {
-  "name": "immutable-history",
-  "version": "0.2.1",
-  "author": "Jamison Dance <jergason@gmail.com> (http://jamisondance.com)",
-  "repository": "https://github.com/kualico/immutable-history",
-  "contributors": [
-    "Sean Hess <seanhess@gmail.com> (http://seanhess.github.io/)"
-  ],
   "description": "History tracking wrapper for Immutable.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immutable-history",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Jamison Dance <jergason@gmail.com> (http://jamisondance.com)",
   "repository": "https://github.com/kualico/immutable-history",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "immutable": "3.0.1"
+    "immutable": "3.0.1",
+    "immutable-cursor": "git://github.com/redbadger/immutable-cursor"
   },
   "devDependencies": {
     "mocha": "^2.0.1"

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ describe('History', function() {
   });
 
   it('appends to this.history when the cursor is changed', function() {
-
+  
   });
 
   it('emits an update event', function(done) {
@@ -67,22 +67,40 @@ describe('History', function() {
       return "newValue";
     })
   });
+
+  it('undo/redo works', function() {
+      var data = Immutable.fromJS({key:"value"})
+      var h = new History(data, function() {});
+      h.cursor.cursor('key').update(function(v) {
+        return "newValue";
+      })
+      h.cursor.cursor('key').update(function(v) {
+        return "newValue1";
+      })
+      h.cursor.cursor('key').update(function(v) {
+        return "newValue2";
+      })
+      assert.equal(h.cursor.get('key'), "newValue2");
+      h.undo();
+      assert.equal(h.cursor.get('key'), "newValue1");
+      h.redo();
+      assert.equal(h.cursor.get('key'), "newValue2");
+      h.undo();
+      assert.equal(h.cursor.get('key'), "newValue1");
+      h.undo();
+      assert.equal(h.cursor.get('key'), "newValue");
+      h.redo();
+      assert.equal(h.cursor.get('key'), "newValue1");
+      h.cursor.cursor('key').update(function(v) {
+        return "newValue3";
+      })
+      assert.equal(h.cursor.get('key'), "newValue3");
+      h.undo();
+      assert.equal(h.cursor.get('key'), "newValue1");
+  });
+
+
+
 });
 
-//var data = Immutable.fromJS({a: 1, b: 2, c: [1,2,3]});
 
-//var history = new History(data, render);
-//var state = history.cursor;
-
-//var hist = history(data, render)
-//hist = history.undo(hist)
-
-//function render(cursor) {
-  //console.log(cursor.deref());
-//}
-
-//state.cursor(['c']).update(function(val) {
-  //return Immutable.fromJS([1,2]);
-//});
-
-//history.undo()


### PR DESCRIPTION
I've updated the code with redo functionality. Facebook has now moved on to a new cursor library.
Read the notice here:
https://github.com/facebook/immutable-js/tree/master/contrib/cursor
The new module:
https://github.com/redbadger/immutable-cursor

I believe that this code is still compatible with the new module without changes. Updating that to that library can be a subsequent update.

Thanks for your work putting this together.